### PR TITLE
Searchbar allow capitals + exchangeAmount doesn't alter when edited

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -8,10 +8,10 @@ const SearchBar = () => {
   const dispatch = useDispatch();
 
   const handleChange = (e) => {
-    const search = e.target.value.toLowerCase();
+    const search = e.target.value;
     const results = data.filter((item) => (
-      item.id.indexOf(search) > -1
-      || item.symbol.indexOf(search) > -1));
+      item.id.indexOf(search.toLowerCase()) > -1
+      || item.symbol.indexOf(search.toLowerCase()) > -1));
     const searchResults = {
       search,
       results,

--- a/src/hooks/useConvertion.js
+++ b/src/hooks/useConvertion.js
@@ -15,7 +15,8 @@ const useConvertion = (prices) => {
   useLayoutEffect(() => {
     const exAmount = exchangeRate * thisCoinAmount;
     setExchangeAmount(fixFloat(exAmount));
-  }, [exchangeRate, thisCoinAmount]);
+    // eslint-disable-next-line
+  }, [exchangeRate]); // Disabled because this Effect should NOT be triggered when thisCoinAmount changes.
 
   const handleThisCoinAmount = (value) => {
     setThisCoinAmount(value);


### PR DESCRIPTION
- Remove `thisCoinAmount` from dependencies array in `useConvertion`, l19.
https://github.com/astroboyReloaded/CoinStats/blob/950b8fafd2903a6ba0b487bc8d32c2fd08c6adc9/src/hooks/useConvertion.js#L18-L19
- Move `.toLowerCase()` to inside the indexOf in the conditional string to allow for Capital letters to show in the `<SearchBar>`.